### PR TITLE
vunit-v5: time-format

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
         "verilog",
         "system verilog",
         "test controller",
-        "test explorer"
+        "test explorer",
+        "Hagenberg",
+        "FH Hagenberg"
     ],
     "activationEvents": [
         "workspaceContains:**/run.py",

--- a/src/VUnit/VUnitTestController.ts
+++ b/src/VUnit/VUnitTestController.ts
@@ -17,7 +17,7 @@ import { ChildProcess } from "child_process";
 
 //TestBench-Status-Matcher
 const cVunitTestEnd : RegExp = /(pass|fail) \(.*\) (.*) \(.*\)/;
-const cVunitTimedTestEnd : RegExp = /(pass|fail) \(.*\) (.*) \((\d+(?:\.\d+)?) seconds\)/;
+const cVunitTimedTestEnd : RegExp = /(pass|fail) \(.*\) (.*) \((\d+(?:\.\d+)?) (seconds|s)\)/;
 const cVunitTestStart : RegExp = /Starting (.*)/;
 const cVunitStopped : RegExp = /Stopped at ([^\s]+) line (\d+)/;
 


### PR DESCRIPTION
+ vunit version 5 changed the output-format for time. => from now: output-formats for both old and new versions are supported.